### PR TITLE
Add Docker configuration for development & production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
+
+ENV PUMA_PORT 3000
+
+RUN touch /etc/inittab
+
+RUN apt-get update && apt-get install -y
+
+EXPOSE $PUMA_PORT
+
+RUN bundle exec rake assets:precompile RAILS_ENV=production \
+  SECRET_KEY_BASE=required_but_does_not_matter_for_assets
+
+ENTRYPOINT ["./run.sh"]

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,9 @@
+FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
+
+RUN touch /etc/inittab
+
+RUN apt-get update && apt-get install -y
+
+RUN bundle install --with development
+
+CMD bundle exec puma -p $PUMA_PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  db:
+    image: postgres
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    env_file: .env
+    environment:
+      RAILS_ENV: development
+    command: bundle exec puma -b tcp://0.0.0.0:3000
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+cd /usr/src/app
+case ${DOCKER_STATE} in
+migrate)
+    echo "Running migrate"
+    bundle exec rake db:migrate
+    ;;
+create)
+    echo "Running create"
+    bundle exec rake db:create
+    bundle exec rake db:migrate
+    bundle exec rake db:seed
+    ;;
+esac
+
+echo "Running app"
+bundle exec puma -p $PUMA_PORT


### PR DESCRIPTION
This adds the following configuration/scripts:
- Dockerfile for production and production-like deployment environments
- Dockerfile.development and Docker Compose configuration for running in development
- Shell script run.sh to allow running one-off tasks on container start when operating on MoJ Cloud Platform infrastructure.