### PR TITLE
move factory_girl and database_cleaner to dev group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,13 +22,13 @@ group :development, :test do
   gem 'launchy'
   gem 'pry-byebug'
   gem 'rspec-rails'
+  gem 'database_cleaner'
+  gem 'factory_girl_rails'
 end
 
 group :test do
   gem 'brakeman'
   gem 'capybara'
-  gem 'database_cleaner'
-  gem 'factory_girl_rails'
   gem 'fuubar'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false


### PR DESCRIPTION
lib/tasks/factory_girl.rake requires these gems, and
Dockerfile.development builds an image with only development gems
included. So, these gems need to be in the development group to be
able to run "docker-compose run web rails db:create db:migrate"