### PR TITLE
tell rcov to ignore .bundle/ directory

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.minimum_coverage 100
 SimpleCov.start do
   add_filter "/spec/"
+  add_filter ".bundle/"
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Prevents gems' test coverage from affecting the project's stats