### PR TITLE
Replace webmock/rest-client with excon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'bcrypt', '~> 3.1.7'
+gem 'excon'
 gem 'govuk_elements_rails'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       railties (>= 4.0, < 5.1)
     equalizer (0.0.11)
     erubis (2.7.0)
+    excon (0.51.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -333,6 +334,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   dotenv-rails
+  excon
   factory_girl_rails
   fuubar
   govuk_elements_form_builder!

--- a/spec/features/request_a_case_spec.rb
+++ b/spec/features/request_a_case_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 require 'support/shared_examples_for_glimr'
 
 RSpec.feature 'Request a brand new case' do
-  include_examples 'glimr availability request', glimrAvailable: 'yes'
-
   case_number = 'TC/2012/00001'
   confirmation_code = 'ABC123'
 
@@ -42,8 +40,13 @@ RSpec.feature 'Request a brand new case' do
     end
 
     describe 'and glimr times out' do
+      let(:excon) {
+        class_double(Excon)
+      }
+
       before do
-        stub_request(:post, 'https://glimr-test.dsd.io/glimravailable').to_timeout
+        expect(excon).to receive(:post).and_raise(Excon::Errors::Timeout)
+        expect(Excon).to receive(:new).and_return(excon)
       end
 
       scenario 'we alert the user' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,23 +19,26 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  config.before(:all) do
+    Excon.defaults[:mock] = true
+  end
+
   config.before(:each) do
     I18n.locale = I18n.default_locale
     DatabaseCleaner.strategy = :transaction
-    stub_request(:post, 'https://glimr-test.dsd.io/glimravailable').
-      with(:headers => {'Accept' => 'application/json'}).
-      to_return(status: 200, body: '{"glimrAvailable":"yes"}')
+    DatabaseCleaner.start
+    Excon.stub(
+      { host: 'glimr-test.dsd.io', path: '/glimravailable' },
+      { status: 200, body: { glimrAvailable: 'yes' }.to_json }
+    )
   end
 
   config.before(:each, js: true) do
     DatabaseCleaner.strategy = :truncation
   end
 
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
   config.after(:each) do
     DatabaseCleaner.clean
+    Excon.stubs.clear
   end
 end


### PR DESCRIPTION
Changing expected headers in the govpay api webmock stubs casued
rest-client to send different headers when running the specs. This was
worrying and neither DS nor I could find an obvious cause.  I decided to
change out to Excon, which is has its own mocking, as it is simpler and
being used successfully by Prison Visit Boookings. This branch is a
refactor of the already-completed glimr api refactor to achieve this.

Webmock and rest-client are being left in as they are still required by
the govpay api refactor feature branch.  I will remove them as part of
the changes on that branch.