### PR TITLE
Set the default host

### DIFF
--- a/.env.circle
+++ b/.env.circle
@@ -2,3 +2,4 @@ GLIMR_API_URL=https://glimr-test.dsd.io
 GLIMR_SUBMIT_PAYMENT_SUCCESS=0
 GOVUK_PAY_API_URL=https://govpay-test.dsd.io
 GOVUK_PAY_API_KEY=deadbeef
+GOV_UK_REDIRECT_HOST=whatever

--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ GLIMR_API_URL=https://glimr-api.taxtribunals.dsd.io/api/tdsapi
 # GOV.UK Pay
 GOVUK_PAY_API_URL=https://publicapi.pymnt.uk/v1
 GOVUK_PAY_API_KEY=deadbeef
+
+# Gov UK pay will redirect back to this host. This env var must be set in production
+# but is not required in dev & test
+GOV_UK_REDIRECT_HOST=your.development.host:port

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,2 +1,7 @@
 require_relative 'application'
 Rails.application.initialize!
+
+# Gov UK pay will redirect back to this host. This env var must be set
+# in production but is not required in dev & test
+Rails.application.routes.default_url_options[:host] =
+  ENV.fetch('GOV_UK_REDIRECT_HOST')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,3 @@
-Rails.application.routes.default_url_options[:host] =
-  'replace-me-with-localhost.com'
-
 Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,5 +14,3 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
   config.action_view.raise_on_missing_translations = true
 end
-
-Rails.application.routes.default_url_options[:host] = 'localhost:3000'


### PR DESCRIPTION
This fixes redirects to gov.uk/pay when the application is running in production mode.