### PR TITLE
don't use ENV.fetch because it breaks jenkins

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,4 +4,4 @@ Rails.application.initialize!
 # Gov UK pay will redirect back to this host. This env var must be set
 # in production but is not required in dev & test
 Rails.application.routes.default_url_options[:host] =
-  ENV.fetch('GOV_UK_REDIRECT_HOST')
+  ENV['GOV_UK_REDIRECT_HOST']


### PR DESCRIPTION
When jenkins builds the docker container, it
doesn't have a value for the environment variable