### PR TITLE
Update to glimr-api-client v0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'bcrypt', '~> 3.1.7'
 gem 'excon'
-gem 'glimr-api-client', '~> 0.1.13'
+gem 'glimr-api-client', '~> 0.2'
 gem 'govuk_elements_rails'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     fuubar (2.2.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
-    glimr-api-client (0.1.13)
+    glimr-api-client (0.2.0)
       excon (~> 0.51)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -314,7 +314,7 @@ DEPENDENCIES
   excon
   factory_girl_rails
   fuubar
-  glimr-api-client (~> 0.1.13)
+  glimr-api-client (~> 0.2)
   govuk-pay-api-client
   govuk_elements_form_builder!
   govuk_elements_rails


### PR DESCRIPTION
This version of the gem gets the case title from the first unpaid
fee liability OR the first paid fee liability (if there are no
unpaid liabilities). This is predicated on a change to GLiMR, such
that the relevant method is called RequestCaseFees (rather than
RequestPayableCaseFees)