### PR TITLE
Handle GlimrApiClient::Case::InvalidCaseNumber

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   rescue_from GlimrApiClient::Unavailable, with: :alert_glimr_is_not_available
-  rescue_from GlimrApiClient::CaseNotFound, with: :case_not_found
+  rescue_from GlimrApiClient::Case::InvalidCaseNumber, with: :case_not_found
 
   protect_from_forgery with: :exception
 

--- a/spec/features/request_a_case_spec.rb
+++ b/spec/features/request_a_case_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'Request a brand new case' do
 
     describe 'a bad case reference' do
       before do
-        expect(GlimrApiClient::Case).to receive(:find).and_raise(GlimrApiClient::CaseNotFound)
+        expect(GlimrApiClient::Case).to receive(:find).and_raise(GlimrApiClient::Case::InvalidCaseNumber)
       end
 
       scenario 'then tell the user the case cannot be found' do
@@ -83,7 +83,7 @@ RSpec.feature 'Request a brand new case' do
 
     describe 'a non-existent case' do
       before do
-        expect(GlimrApiClient::Case).to receive(:find).and_raise(GlimrApiClient::CaseNotFound)
+        expect(GlimrApiClient::Case).to receive(:find).and_raise(GlimrApiClient::Case::InvalidCaseNumber)
       end
 
       scenario 'then tell the user the case cannot be found' do

--- a/spec/models/case_request_spec.rb
+++ b/spec/models/case_request_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe CaseRequest do
     context "when case does not exist in glimr" do
       before do
         allow(Fee).to receive(:create!).and_return(fee)
-        allow(GlimrApiClient::Case).to receive(:find).and_raise(GlimrApiClient::CaseNotFound)
+        allow(GlimrApiClient::Case).to receive(:find).and_raise(GlimrApiClient::Case::InvalidCaseNumber)
       end
 
       it "raises an error" do
         expect {
           case_request.process!
-        }.to raise_error(GlimrApiClient::CaseNotFound)
+        }.to raise_error(GlimrApiClient::Case::InvalidCaseNumber)
       end
     end
 


### PR DESCRIPTION
The glimr-api-client gem used to raise GlimrApiClient::CaseNotFound
but now it raises GlimrApiClient::Case::InvalidCaseNumber
So, this application needs to handle those exceptions.