### PR TITLE
Add dummy env vars to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 
 ENV PUMA_PORT 3000
 
+ENV DATABASE_URL         replace_this_at_build_time
+ENV GLIMR_API_URL        replace_this_at_build_time
+ENV GOVUK_PAY_API_KEY    replace_this_at_build_time
+ENV GOVUK_PAY_API_URL    replace_this_at_build_time
+ENV GOV_UK_REDIRECT_HOST replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN apt-get update && apt-get install -y


### PR DESCRIPTION
This enables jenkins to build the docker image. The dummy values
will be overridden when the container is started.