### PR TITLE
Do not display unusable options

### DIFF
--- a/app/views/case_requests/show.html.erb
+++ b/app/views/case_requests/show.html.erb
@@ -47,10 +47,6 @@
             <br />
             <%= t('.if_you_have_an_account') %>
           </label>
-          <label class='block-label selection-button-radio'>
-            <%= radio_button_tag(:payment_method, :cheque) %>
-            <strong><%= t('.cheque') %></strong>
-          </label>
         </fieldset>
         <p>
           <%= submit_tag(t('.continue'), class: 'button') %>

--- a/spec/features/request_a_case_spec.rb
+++ b/spec/features/request_a_case_spec.rb
@@ -67,10 +67,6 @@ RSpec.feature 'Request a brand new case' do
         scenario 'Help with fees' do
           expect(page).to have_text("Help with fees")
         end
-
-        scenario 'Cheque' do
-          expect(page).to have_text("Cheque")
-        end
       end
     end
 


### PR DESCRIPTION
The workflow around this is not yet complete.  I have removed the radio
button for now.