### PR TITLE
disable CSRF check for JSON API requests

### DIFF
--- a/app/controllers/case_requests_controller.rb
+++ b/app/controllers/case_requests_controller.rb
@@ -2,6 +2,8 @@ class CaseRequestsController < ApplicationController
   rescue_from GlimrApiClient::Case::InvalidCaseNumber, with: :case_not_found
   include SimplifiedLogging
 
+  protect_from_forgery unless: -> { request.format.json? }
+
   def new
     @case_request = CaseRequest.new
   end


### PR DESCRIPTION
The datacapture tool makes a server-to-server API
call, which will fail without this change.