### PR TITLE
use EXTERNAL_URL env var, when building url for API

### DIFF
--- a/app/controllers/case_requests_controller.rb
+++ b/app/controllers/case_requests_controller.rb
@@ -60,9 +60,18 @@ class CaseRequestsController < ApplicationController
   def process_json(case_request)
     if case_request.save
       case_request.process!
-      render json: { return_url: case_request_url(@case_request.id) }
+
+      render json: { return_url: redirect_url }
     else
       render json: { error: case_request.errors }
+    end
+  end
+
+  def redirect_url
+    if ENV['EXTERNAL_URL']
+      ENV['EXTERNAL_URL'] + case_request_path(@case_request.id)
+    else
+      case_request_url(@case_request.id)
     end
   end
 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,16 @@
+# Database
+DATABASE_URL=postgresql://postgres@localhost/payments_alpha_development
+
+# GLiMR API Location
+GLIMR_API_URL=[URL of the GLiMR API]
+
+# Whether or not to post payment success to GLiMR
+#  (turning this off means you can test payment for the same liability
+#   over and over again. Anything non-falsy means it's on).
+UPDATE_GLIMR=true
+
+# GOV.UK Pay
+GOVUK_PAY_API_URL=https://publicapi.payments.service.gov.uk/v1
+GOVUK_PAY_API_KEY=[gov.uk pay API key]
+
+EXTERNAL_URL=http://localhost:3000

--- a/spec/requests/datacapture_json_spec.rb
+++ b/spec/requests/datacapture_json_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe 'Hypermedia link for datacapture api call', type: :request do
           expect(response.body).to eq('{"return_url":"https://external.url/case_requests/ABC123"}')
         end
       end
-
     end
 
     context 'the case does not exist on GLiMR' do

--- a/spec/requests/datacapture_json_spec.rb
+++ b/spec/requests/datacapture_json_spec.rb
@@ -43,6 +43,21 @@ RSpec.describe 'Hypermedia link for datacapture api call', type: :request do
           as: :json
         expect(response.body).to eq('{"return_url":"http://www.example.com/case_requests/ABC123"}')
       end
+
+      context "when EXTERNAL_URL is set" do
+        before do
+          allow(ENV).to receive(:[]).with('EXTERNAL_URL').and_return('https://external.url')
+        end
+
+        it 'returns a url for redirecting the user' do
+          post '/case_requests',
+            params: request_details,
+            headers: headers,
+            as: :json
+          expect(response.body).to eq('{"return_url":"https://external.url/case_requests/ABC123"}')
+        end
+      end
+
     end
 
     context 'the case does not exist on GLiMR' do


### PR DESCRIPTION
Depending on the application's context, it might
not know its own FQDN (e.g. if running in a 
docker-compose environment). So, if this env var
is defined, use it to build the redirect URL.