### PR TITLE
add a workaround for staging error

### DIFF
--- a/app/models/case_request.rb
+++ b/app/models/case_request.rb
@@ -32,10 +32,40 @@ class CaseRequest < ApplicationRecord
   end
 
   def glimr_case_request
+    # This should raise a GlimrApiClient::Case::InvalidCaseNumber
+    # exception if the case is not found. But, in the staging (but
+    # not dev) environment, that exception is being swallowed, and
+    # we end up with a 'case' like this;
+    #
+    #  <GlimrApiClient::Case:0x007f94ecfc5750
+    #    @body=
+    #     "{\"message\":\"Invalid CaseNumber/CaseConfirmationCode
+    #     combination xxx / YYY\",\"glimrerrorcode\":213}",
+    #    @case_reference="xxx",
+    #    @confirmation_code="yyy">
+    #
+    # It's only when we try and call a method on this object that we
+    # get a KeyError. So, in the staging environment, the user sees
+    # a low-level application error when they search for a case with
+    # incorrect reference/confirmation_code
+    #
+    # The call to fees and the rescue below are a nasty hack to
+    # workaround this issue.  TODO: fix this properly, possibly by
+    # adding a 'has_errors?' method to the Case class, or by finding
+    # and fixing the underlying issue which is preventing the exception
+    # from bubbling up properly.
+
     @glimr_case_request ||= GlimrApiClient::Case.find(
       case_reference,
       confirmation_code
     )
+
+    # If we're looking at a failed find, this will raise a KeyError
+    @glimr_case_request.fees
+
+    @glimr_case_request
+  rescue KeyError
+    raise GlimrApiClient::Case::InvalidCaseNumber
   end
 
   delegate :fees, :title, to: :glimr_case_request

--- a/spec/models/case_request_spec.rb
+++ b/spec/models/case_request_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe CaseRequest do
   }
 
   describe '#initialize' do
+    context 'when InvalidCaseNumber fails to propagate' do
+      let(:case_req) { build(:case_request, case_reference: 'xxx', confirmation_code: 'yyy') }
+
+      before do
+        stub_request(:post, "https://glimr-test.dsd.io/requestcasefees").
+          with(
+            body: "{\"jurisdictionId\":8,\"caseNumber\":\"xxx\",\"confirmationCode\":\"yyy\"}",
+
+            headers: {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'Host' => 'glimr-test.dsd.io:443'
+            }
+          ).
+          to_return(status: 200, body: "{\"message\":\"Invalid CaseNumber/CaseConfirmationCode combination xxx / YYY\",\"glimrerrorcode\":213}", headers: {})
+      end
+
+      it "raises" do
+        expect { case_req.title }.to raise_error(GlimrApiClient::Case::InvalidCaseNumber)
+      end
+    end
+
     it 'does not save without a case reference' do
       expect { build(:case_request, case_reference: nil).save! }.
         to raise_error(ActiveRecord::RecordInvalid)


### PR DESCRIPTION
In the staging environment, the Glimr API Client
'InvalidCaseNumber' exception is not triggering
the controller 'rescue_from'. In development, it
works fine.
This is a quick hack to workaround this issue, 
until we can come up with a proper fix.