### PR TITLE
Ensure healthcheck works even when glimr is down

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,4 +1,6 @@
 class HealthcheckController < ApplicationController
+  rescue_from GlimrApiClient::Unavailable, with: :index
+
   respond_to :json
 
   def index


### PR DESCRIPTION
The main rescue that fired when glimr was unavailable also caught the
healthcheck endpoint and so returned the client-facing page.