### PR TITLE
Ensue case references are consistent

### DIFF
--- a/app/models/case_request.rb
+++ b/app/models/case_request.rb
@@ -3,6 +3,7 @@ class CaseRequest < ApplicationRecord
 
   validates :case_reference, presence: true
   validates :confirmation_code, presence: true
+  before_save :upcase_case_reference
 
   def process!
     fees.each do |fee|
@@ -19,6 +20,10 @@ class CaseRequest < ApplicationRecord
   end
 
   private
+
+  def upcase_case_reference
+    case_reference.upcase!
+  end
 
   def prepare_case_fee(fee)
     case_fees << Fee.new(

--- a/spec/models/case_request_spec.rb
+++ b/spec/models/case_request_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe CaseRequest do
     )
   }
 
+  describe '#case_reference' do
+    let(:case_reference) { "tc/2016/04512" }
+
+    before do
+      allow(Fee).to receive(:new).and_return(fee)
+      allow(GlimrApiClient::Case).to receive(:find).and_return(glimr_case_request)
+      case_request.process!
+    end
+
+    specify do
+      expect(case_request.case_reference).to eq(case_reference.upcase)
+    end
+  end
+
   describe '#initialize' do
     context 'when InvalidCaseNumber fails to propagate' do
       let(:case_req) { build(:case_request, case_reference: 'xxx', confirmation_code: 'yyy') }


### PR DESCRIPTION
It appears GLiMR is not case-sensitive. This change ensures we always
deal in upcased case reference numbers.