### PR TITLE
rename /healthcheck.json to /status.json

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,9 +1,9 @@
-class HealthcheckController < ApplicationController
+class StatusController < ApplicationController
   rescue_from GlimrApiClient::Unavailable, with: :index
 
   respond_to :json
 
   def index
-    respond_with(Healthcheck.check.to_json)
+    respond_with(Status.check.to_json)
   end
 end

--- a/app/services/status.rb
+++ b/app/services/status.rb
@@ -1,5 +1,5 @@
 require 'glimr_api_client'
-class Healthcheck
+class Status
   def self.check
     new.check
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :healthcheck, only: [:index]
+  resources :status, only: [:index]
 end

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe HealthcheckController do
+RSpec.describe StatusController do
   let(:status_response) do
     {
       service_status: 'ok',
@@ -24,12 +24,12 @@ RSpec.describe HealthcheckController do
     # This is an expediency to avoid having to add multiple extra stubs to
     # check something low-priority.
     # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(Healthcheck).to receive(:version).and_return('ABC123')
+    allow_any_instance_of(Status).to receive(:version).and_return('ABC123')
     # rubocop:enable RSpec/AnyInstance
   end
 
   # This is very-happy-path to ensure the controller responds.  The bulk of the
-  # healthcheck is tested in spec/services/healthcheck_spec.rb.
+  # statuscheck is tested in spec/services/status_spec.rb.
   describe '#index' do
     context 'happy path' do
       before do

--- a/spec/services/status_spec.rb
+++ b/spec/services/status_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Healthcheck do
+RSpec.describe Status do
   let(:glimr_available) {
     instance_double(GlimrApiClient::Available, available?: true)
   }


### PR DESCRIPTION
"healthcheck" has a specific meaning for the
platforms team (should this endpoint receive
traffic from the load-balancer), so we should be
using /status.json for our system status endpoints

NB: There is a failing spec on the master branch
of the fees app. This commit does not address that.

https://www.pivotaltracker.com/story/show/142380681